### PR TITLE
To prevent the creation of a new record in the database, correct the hash key.

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -360,8 +360,7 @@ class Builder
 
         foreach ($listKey as $key) {
             $attributeValue = $attributes[$key] ?? '*';
-            $attributeValue = is_string($attributeValue) ? $attributeValue : json_encode($attributeValue);
-            $stringKey .= $key . ':' . $attributeValue . ':';
+            $stringKey .= $key . ':' . ($attributeValue === '*' ? '*' : $this->model->castAttributeBeforeSave($key, $attributeValue)) . ':';
         }
 
         return $this->model->getTable() . ":" . rtrim($stringKey, ':');

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -359,7 +359,9 @@ class Builder
         $stringKey = '';
 
         foreach ($listKey as $key) {
-            $stringKey .= $key . ':' . ($attributes[$key] ?? "*") . ':';
+            $attributeValue = $attributes[$key] ?? '*';
+            $attributeValue = is_string($attributeValue) ? $attributeValue : json_encode($attributeValue);
+            $stringKey .= $key . ':' . $attributeValue . ':';
         }
 
         return $this->model->getTable() . ":" . rtrim($stringKey, ':');

--- a/src/Model.php
+++ b/src/Model.php
@@ -513,6 +513,10 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
                         $item = $item->format($this->getDateFormat());
                     } elseif (is_array($item)) {
                         $item = json_encode($item);
+                    } elseif (is_bool($item)) {
+                        $item = (int)filter_var($item, FILTER_VALIDATE_BOOLEAN);
+                    } elseif ($this->isEnumCastable($key)) {
+                        $item = $item->value;
                     }
 
                     return (string) $item;
@@ -579,6 +583,10 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
                     $item = $item->format($this->getDateFormat());
                 } elseif (is_array($item)) {
                     $item = json_encode($item);
+                } elseif (is_bool($item)) {
+                    $item = (int)filter_var($item, FILTER_VALIDATE_BOOLEAN);
+                } elseif ($this->isEnumCastable($key)) {
+                    $item = $item->value;
                 }
 
                 return (string) $item;
@@ -661,6 +669,10 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
                         $item = $item->format($model->getDateFormat());
                     } elseif (is_array($item)) {
                         $item = json_encode($item);
+                    } elseif (is_bool($item)) {
+                        $item = (int)filter_var($item, FILTER_VALIDATE_BOOLEAN);
+                    } elseif ($this->isEnumCastable($key)) {
+                        $item = $item->value;
                     }
 
                     return (string) $item;

--- a/src/Model.php
+++ b/src/Model.php
@@ -5,6 +5,9 @@ namespace Alvin0\RedisModel;
 
 use Alvin0\RedisModel\Exceptions\KeyExistException;
 use Alvin0\RedisModel\Exceptions\RedisModelException;
+use Alvin0\RedisModel\Exceptions\MassAssignmentException;
+use Alvin0\RedisModel\Exceptions\ErrorConnectToRedisException;
+use Alvin0\RedisModel\Exceptions\MissingAttributeException;
 use ArrayAccess;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\CanBeEscapedWhenCastToString;

--- a/src/Model.php
+++ b/src/Model.php
@@ -511,6 +511,8 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
                     // If the attribute is a Carbon instance, format it using the model's date format
                     if ($item instanceof Carbon) {
                         $item = $item->format($this->getDateFormat());
+                    } elseif (is_array($item)) {
+                        $item = json_encode($item);
                     }
 
                     return (string) $item;
@@ -575,14 +577,8 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
                 // If the attribute is a Carbon instance, format it using the model's date format
                 if ($item instanceof Carbon) {
                     $item = $item->format($this->getDateFormat());
-                }
-
-                if (is_array($item)) {
+                } elseif (is_array($item)) {
                     $item = json_encode($item);
-                }
-
-                if (is_bool($item)) {
-                    $item = (int) filter_var($item, FILTER_VALIDATE_BOOLEAN);
                 }
 
                 return (string) $item;
@@ -663,14 +659,8 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
                     // If the attribute is a Carbon instance, format it using the model's date format
                     if ($item instanceof Carbon) {
                         $item = $item->format($model->getDateFormat());
-                    }
-
-                    if (is_array($item)) {
+                    } elseif (is_array($item)) {
                         $item = json_encode($item);
-                    }
-
-                    if (is_bool($item)) {
-                        $item = (int) filter_var($item, FILTER_VALIDATE_BOOLEAN);
                     }
 
                     return (string) $item;

--- a/src/Model.php
+++ b/src/Model.php
@@ -505,21 +505,7 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
             $attributes = $this->getAttributesForInsert();
             if ($this->isValidationKeyAndSubKeys($attributes)) {
                 $attributes = collect($attributes)->map(function ($item, $key) {
-                    // Cast the attribute if necessary
-                    $item = $this->hasCast($key) ? $this->castAttribute($key, $item) : $item;
-
-                    // If the attribute is a Carbon instance, format it using the model's date format
-                    if ($item instanceof Carbon) {
-                        $item = $item->format($this->getDateFormat());
-                    } elseif (is_array($item)) {
-                        $item = json_encode($item);
-                    } elseif (is_bool($item)) {
-                        $item = (int)filter_var($item, FILTER_VALIDATE_BOOLEAN);
-                    } elseif ($this->isEnumCastable($key)) {
-                        $item = $item->value;
-                    }
-
-                    return (string) $item;
+                    return (string) $this->castAttributeBeforeSave($key, $item);
                 })->toArray();
 
                 $keyOrigin = $build->compileHashByFields($this->parseAttributeKeyBooleanToInt(($this->getOriginal())));
@@ -536,6 +522,42 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
         }
 
         return false;
+    }
+
+    /**
+     * Casts and prepares an attribute value before saving it to the database.
+     *
+     * @param string $key 
+     * @param mixed $value
+     *
+     * @return mixed The 
+     */
+    protected function castAttributeBeforeSave($key, $value) {
+        // Cast the attribute if necessary
+        $value = $this->hasCast($key) ? $this->castAttribute($key, $value) : $value;
+
+        // If the attribute is a Carbon instance, format it using the model's date format
+        if ($value instanceof Carbon) {
+            $value = $value->format($this->getDateFormat());
+        }
+    
+        // If the attribute is an array, encode it to JSON
+        if (is_array($value)) {
+            $value = json_encode($value);
+        }
+    
+        // If the attribute is a boolean, cast it to an integer
+        if (is_bool($value)) {
+            $value = (int) filter_var($value, FILTER_VALIDATE_BOOLEAN);
+        }
+    
+        // If the attribute is enum castable, extract its value
+        if ($this->isEnumCastable($key)) {
+            $value = $value->value;
+        }
+
+        // Return the transformed and casted attribute value
+        return $value;
     }
 
     /**
@@ -575,21 +597,7 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
 
         if ($this->isValidationKeyAndSubKeys($attributes)) {
             $attributes = collect($attributes)->map(function ($item, $key) {
-                // Cast the attribute if necessary
-                $item = $this->hasCast($key) ? $this->castAttribute($key, $item) : $item;
-
-                // If the attribute is a Carbon instance, format it using the model's date format
-                if ($item instanceof Carbon) {
-                    $item = $item->format($this->getDateFormat());
-                } elseif (is_array($item)) {
-                    $item = json_encode($item);
-                } elseif (is_bool($item)) {
-                    $item = (int)filter_var($item, FILTER_VALIDATE_BOOLEAN);
-                } elseif ($this->isEnumCastable($key)) {
-                    $item = $item->value;
-                }
-
-                return (string) $item;
+                return (string) $this->castAttributeBeforeSave($key, $item);
             })->toArray();
 
             $keyInsert = $build->compileHashByFields($this->parseAttributeKeyBooleanToInt($attributes));
@@ -661,21 +669,7 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
                 }
 
                 $inserts[$key] = collect($attributes)->map(function ($item, $key) use ($model) {
-                    // Cast the attribute if necessary
-                    $item = $model->hasCast($key) ? $model->castAttribute($key, $item) : $item;
-
-                    // If the attribute is a Carbon instance, format it using the model's date format
-                    if ($item instanceof Carbon) {
-                        $item = $item->format($model->getDateFormat());
-                    } elseif (is_array($item)) {
-                        $item = json_encode($item);
-                    } elseif (is_bool($item)) {
-                        $item = (int)filter_var($item, FILTER_VALIDATE_BOOLEAN);
-                    } elseif ($this->isEnumCastable($key)) {
-                        $item = $item->value;
-                    }
-
-                    return (string) $item;
+                    return (string) $this->castAttributeBeforeSave($key, $item);
                 })->toArray();
             } else {
                 return false;

--- a/src/Model.php
+++ b/src/Model.php
@@ -535,7 +535,7 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
      *
      * @return mixed The 
      */
-    protected function castAttributeBeforeSave($key, $value) {
+    public function castAttributeBeforeSave($key, $value) {
         // Cast the attribute if necessary
         $value = $this->hasCast($key) ? $this->castAttribute($key, $value) : $value;
 

--- a/src/Model.php
+++ b/src/Model.php
@@ -672,7 +672,7 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
                 }
 
                 $inserts[$key] = collect($attributes)->map(function ($item, $key) use ($model) {
-                    return (string) $this->castAttributeBeforeSave($key, $item);
+                    return (string) $model->castAttributeBeforeSave($key, $item);
                 })->toArray();
             } else {
                 return false;

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -9,7 +9,6 @@ beforeEach(function () {
 
 it('a user can be created without id', function ($userInput, $expect) {
     $user = User::create($userInput);
-
     expect($user->name)->toEqual($expect['name']);
     expect($user->email)->toEqual($expect['email']);
 })->with([
@@ -28,6 +27,7 @@ it('a user can be created without id', function ($userInput, $expect) {
 ]);
 
 it('can insert multiple users without id', function ($data) {
+
     User::insert($data);
 
     $users = User::get();
@@ -118,7 +118,7 @@ it('a user can be created, updated, and deleted', function ($userInput, $expect)
     ],
 ]);
 
-it('can retrieve all users', function ($setup) {
+it('can retrieve all users', function () {
     expect(User::all()->count())->toBeGreaterThan(0);
 })->with([
     [
@@ -140,10 +140,9 @@ it('can retrieve all users', function ($setup) {
     ],
 ]);
 
-it('can retrieve a single user by ID', function ($createData, $expect) {
-    $createData();
-
+it('can retrieve a single user by ID', function ($expect) {
     $user = User::find(1);
+
     expect($user->name)->toEqual($expect['name']);
     expect($user->email)->toEqual($expect['email']);
 })->with([
@@ -157,9 +156,7 @@ it('can retrieve a single user by ID', function ($createData, $expect) {
     ],
 ]);
 
-it('can retrieve users matching a given criteria', function ($createData, $expect) {
-    $createData();
-
+it('can retrieve users matching a given criteria', function ($expect) {
     $users = User::where('name', 'Nuno*')->get();
     expect($users->count())->toBeGreaterThan(0);
 
@@ -281,4 +278,95 @@ it('it cant insert multiple users with transaction', function ($data) {
 
         return $data;
     }
+]);
+
+it('can retrieve users by email', function () {
+    $users = User::query()->where('email', 'nuno_naduro@example.com')->get();
+
+    expect(2)->toEqual($users->count());
+})->with([
+    [
+        fn() => User::insert([
+            ['name' => 'Nuno Maduro', 'email' => 'nuno_naduro@example.com'],
+            ['name' => 'Nuno Maduro', 'email' => 'nuno_naduro@example.com'],
+            ['name' => 'Nuno Maduro', 'email' => 'nuno_naduro@example.net'],
+        ]),
+    ],
+    [
+        fn() => User::insert([
+            ['name' => 'Nuno Maduro', 'email' => 'nuno_naduro@example.net'],
+            ['name' => 'Nuno Maduro', 'email' => 'nuno_naduro@example.com'],
+            ['name' => 'Nuno Maduro', 'email' => 'nuno_naduro@example.com'],
+        ]),
+    ]
+]);
+
+it('can create user assigning model property values', function ($userData, $expected) {
+    $user = User::query()->where('email', 'nuno_naduro@example.com')->first();
+
+    expect($expected['name'])->toEqual($user->name);
+    expect($expected['email'])->toEqual($user->email);
+})->with([
+    [
+        function () {
+            $user = new User;
+            $user->name = 'Nuno Maduro';
+            $user->email = 'nuno_naduro@example.com';
+            $user->save();
+        },
+        ['name' => 'Nuno Maduro', 'email' => 'nuno_naduro@example.com'],
+    ]
+]);
+
+it('can update user subKey without duplication', function () {
+    expect(1)->toEqual(User::query()->count());
+})->with([
+    [
+        function () {
+            $user = new User;
+            $user->name = 'Nuno Maduro';
+            $user->email = 'nuno_naduro@example.com';
+            $user->save();
+            $user->email = 'nuno_naduro@example.net';
+            $user->save();
+        },
+    ],
+    [
+        function () {
+            $user = new User;
+            $user->name = 'Nuno Maduro';
+            $user->email = 'nuno_naduro@example.com';
+            $user->save();
+            $user->name = 'Nuno';
+            $user->email = 'nuno_naduro@example.net';
+            $user->save();
+        },
+    ]
+]);
+
+it('can update user primaryKey without duplication', function () {
+    expect(1)->toEqual(User::query()->count());
+})->with([
+    [
+        function () {
+            $user = new User;
+            $user->id = '1';
+            $user->name = 'Nuno Maduro';
+            $user->email = 'nuno_naduro@example.com';
+            $user->save();
+            $user->id = 2;
+            $user->save();
+        },
+    ],
+    [
+        function () {
+            $user = new User;
+            $user->id = 1;
+            $user->name = 'Nuno Maduro';
+            $user->email = 'nuno_naduro@example.com';
+            $user->save();
+            $user->id = 2;
+            $user->save();
+        },
+    ]
 ]);

--- a/tests/Models/User.php
+++ b/tests/Models/User.php
@@ -3,6 +3,11 @@ namespace Alvin0\RedisModel\Tests\Models;
 
 use Alvin0\RedisModel\Model;
 
+/**
+ * @property $id
+ * @property $email
+ * @property $name
+ */
 class User extends Model
 {
     /**


### PR DESCRIPTION
A new record was accidentally created during the update process due to the hash key string being encoded twice.